### PR TITLE
Add missing grid imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: prada
-Version: 1.47.0
+Version: 1.47.1
 Title: Data analysis for cell-based functional assays
 Author:  Florian Hahne <florian.hahne@novartis.com>, Wolfgang Huber <huber@ebi.ac.uk>, Markus Ruschhaupt, Joern Toedling <toedling@ebi.ac.uk>, Joseph Barry <joseph.barry@embl.de>
 Maintainer: Florian Hahne <florian.hahne@novartis.com>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,9 +14,10 @@ importFrom(graphics, barplot, locator, par, plot.new, points,
            polygon, segments, smoothScatter, title)
 importFrom(grDevices, colorRampPalette, densCols, dev.cur, dev.off)
 importFrom(grid, convertHeight, convertWidth, convertX, convertY,
-           current.transform, current.viewport, current.vpTree, gpar,
-           grid.circle, grid.lines, grid.polygon, grid.rect, grid.text,
-           grid.yaxis, popViewport, pushViewport, unit, viewport)
+           current.transform, current.viewport, current.vpTree,
+           downViewport, gpar, grid.circle, grid.lines, grid.polygon,
+           grid.rect, grid.segments, grid.text, grid.yaxis, popViewport,
+           pushViewport, unit, upViewport, viewport)
 importFrom(MASS, cov.rob)
 importFrom(methods, is, new, validObject)
 importFrom(RColorBrewer, brewer.pal)


### PR DESCRIPTION
Added "grid.segments", "upViewport" and "downViewport" to `importFrom("grid" ...)` in the NAMESPACE file. This fixes the issue of the function `devRes()` failing when grid was not attached.